### PR TITLE
Wrong behavior when more than `-` in the path to the tool

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -50,7 +50,8 @@ static GFile *current_dir()
 
 static gchar *
 extract_toolname(const char *name) {
-  gchar *pos = g_strstr_len(name, -1, "-");
+  gchar *pos = strrchr(name, '/');
+  pos = strchr(pos, '-');
 
   if (pos == NULL || *++pos == '\0') {
     return NULL;


### PR DESCRIPTION
Hi,

Thank you very much for your tool, it works great and I was able to import a `compile_commands.json` for the whole gcc source!
I found a little bug though. If there are spurious `-` in the path it will split on the first and the tool detection won't work. Here is a patch which use the last `-` instead.

It is not much more robust though, as I am writing I realize that you might want something along the line of first `-` after the last `/`, because tools such as `gcc-elf` would not work the intended way as well...

I open the pull-request anyway but I'll come back with a better patch.

Edit: I force-pushed with the following behavior: 1) find the last `/` 2) find the first `-` from the last `/`. This should work in most cases.