### PR TITLE
fix: wrong behavior if no / in the path

### DIFF
--- a/cc.c
+++ b/cc.c
@@ -51,7 +51,7 @@ static GFile *current_dir()
 static gchar *
 extract_toolname(const char *name) {
   gchar *pos = strrchr(name, '/');
-  pos = strchr(pos, '-');
+  pos = strchr(pos ? pos : name, '-');
 
   if (pos == NULL || *++pos == '\0') {
     return NULL;


### PR DESCRIPTION
In fact, there was still a bug. If there is no `/` in the path, the first call returns `NULL`, I added a check so that if there is no `/` it does not crash. Sorry, I should have pushed yesterday before you merged but you were faster than me :)